### PR TITLE
API: Clean up img_to_relative_xyi and put input validation in new file.

### DIFF
--- a/skxray/tests/test_core.py
+++ b/skxray/tests/test_core.py
@@ -454,22 +454,22 @@ def test_subtract_reference_images():
 def _fail_img_to_relative_xyi_helper(input_dict):
     core.img_to_relative_xyi(**input_dict)
 
+
 def test_img_to_relative_fails():
     fail_dicts = [
-        # invalid values of x and y
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_x': -1, 'pixel_size_y': -1},
-        # valid value of x, no value for y
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_x': 1},
-        # valid value of y, no value for x
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_y': 1},
-        # valid value of y, invalid value for x
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_x': -1, 'pixel_size_y': 1},
-        # valid value of x, invalid value for y
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_x': 1, 'pixel_size_y': -1},
-        # invalid value of x, no value for y
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_x': -1,},
-        # invalid value of y, no value for x
-        {'img': np.ones((100, 100)),'cx': 50, 'cy': 50, 'pixel_size_y': -1,},
+        # both x and y invalid
+        {'image': np.ones((100, 100)), 'cx': 50, 'cy': 50,
+         'pixel_size': (-1, -1)},
+        {'image': np.ones((100, 100)), 'cx': 50, 'cy': 50,
+         'pixel_size': (0, 0)},
+        # given x but not given y should fail -- that's weird
+        {'image': np.ones((100, 100)), 'cx': 50, 'cy': 50,
+         'pixel_size': (1, None)},
+        # one valid, one invalid
+        {'image': np.ones((100, 100)), 'cx': 50, 'cy': 50,
+         'pixel_size': (1, 0)},
+        {'image': np.ones((100, 100)), 'cx': 50, 'cy': 50,
+         'pixel_size': (1, -1)},
     ]
     for failer in fail_dicts:
         yield _fail_img_to_relative_xyi_helper, failer
@@ -497,7 +497,7 @@ def test_img_to_relative_xyi(random_seed=None):
     cy_lst = [0, cy, ny]
     for cx, cy in zip(cx_lst, cy_lst):
         # call the function
-        x, y, i = img_to_relative_xyi(img=img, cx=cx, cy=cy)
+        x, y, i = img_to_relative_xyi(img, cx=cx, cy=cy)
         logger.debug('y {0}'.format(y))
         logger.debug('sum(y) {0}'.format(sum(y)))
         expected_total_y = sum(np.arange(ny, dtype=np.int64) - cy) * nx

--- a/skxray/validations.py
+++ b/skxray/validations.py
@@ -1,0 +1,53 @@
+#! encoding: utf-8
+# ######################################################################
+# Copyright (c) 2014, Brookhaven Science Associates, Brookhaven        #
+# National Laboratory. All rights reserved.                            #
+#                                                                      #
+# Redistribution and use in source and binary forms, with or without   #
+# modification, are permitted provided that the following conditions   #
+# are met:                                                             #
+#                                                                      #
+# * Redistributions of source code must retain the above copyright     #
+#   notice, this list of conditions and the following disclaimer.      #
+#                                                                      #
+# * Redistributions in binary form must reproduce the above copyright  #
+#   notice this list of conditions and the following disclaimer in     #
+#   the documentation and/or other materials provided with the         #
+#   distribution.                                                      #
+#                                                                      #
+# * Neither the name of the Brookhaven Science Associates, Brookhaven  #
+#   National Laboratory nor the names of its contributors may be used  #
+#   to endorse or promote products derived from this software without  #
+#   specific prior written permission.                                 #
+#                                                                      #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS  #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT    #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS    #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE       #
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,           #
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES   #
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR   #
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)   #
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,  #
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OTHERWISE) ARISING   #
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   #
+# POSSIBILITY OF SUCH DAMAGE.                                          #
+########################################################################
+"""
+This module is for the 'core' data types.
+"""
+
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import six
+
+
+def pixel_size(val):
+    if len(val) != 2:
+        raise ValueError("pixel_size must be a pair of conversion factors "
+                         "from pixels to microns, (x, y).")
+    if any([v <= 0 for v in val]):
+        raise ValueError("pixel_size must be a pair of conversion factors "
+                         "from pixels to microns, (x, y). Both must be "
+                         "positive.")


### PR DESCRIPTION
This closes #240 by fixing minor issues in the API to `img_to_relative_xyi`. More importantly, it introduces a new file, `validations.py` with a function that is here used to check that `pixel_size` make sense. That function, available at `validations.pixel_size`, should be used in many other places as well. And we can add more functions for other common arguments.

There may be a fancier way to do this, but let's keep it simple for now. Reusing input validations will save a lot of code and mental effort.