### PR TITLE
ENH/TST: optimize CDI code,

### DIFF
--- a/skxray/cdi.py
+++ b/skxray/cdi.py
@@ -323,9 +323,6 @@ def cdi_recon(diffracted_pattern, sample_obj, sup,
     obj_avg = np.zeros_like(diffracted_pattern).astype(complex)
     avg_i = 0
 
-    obj_a = np.zeros_like(obj_avg)
-    obj_b = np.zeros_like(obj_avg)
-
     time_start = time.time()
     for n in range(n_iterations):
         obj_old = np.array(sample_obj)

--- a/skxray/cdi.py
+++ b/skxray/cdi.py
@@ -44,7 +44,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import numpy as np
 import time
-from scipy import signal
 from scipy.ndimage.filters import gaussian_filter
 
 import logging
@@ -152,47 +151,6 @@ def find_support(sample_obj,
     return conv_fun >= (sw_threshold*conv_max)
 
 
-def pi_support(sample_obj, index_v):
-    """
-    Define sample shape by cutting unnecessary values.
-
-    Parameters
-    ----------
-    sample_obj : array
-        sample data
-    index_v : array
-        index to define sample area
-
-    Returns
-    -------
-    sample_obj : array
-        sample object with proper cut.
-    """
-    sample_obj = np.array(sample_obj)
-    sample_obj[index_v] = 0
-    return sample_obj
-
-
-def cal_relative_error(x_old, x_new):
-    """
-    Relative error is calculated as the ratio of the difference between the new and
-    the original arrays to the norm of the original array.
-
-    Parameters
-    ----------
-    x_old : array
-        previous data set
-    x_new : array
-        new data set
-
-    Returns
-    -------
-    float :
-        relative error
-    """
-    return np.linalg.norm(x_new - x_old)/np.linalg.norm(x_old)
-
-
 def cal_diff_error(sample_obj, diffracted_pattern):
     """
     Calculate the error in q space.
@@ -210,7 +168,8 @@ def cal_diff_error(sample_obj, diffracted_pattern):
         relative error in q space
     """
     new_diff = np.abs(np.fft.fftn(sample_obj)) / np.sqrt(np.size(sample_obj))
-    return cal_relative_error(diffracted_pattern, new_diff)
+    return (np.linalg.norm(new_diff - diffracted_pattern) /
+            np.linalg.norm(diffracted_pattern))
 
 
 def generate_random_phase_field(diffracted_pattern):
@@ -364,6 +323,9 @@ def cdi_recon(diffracted_pattern, sample_obj, sup,
     obj_avg = np.zeros_like(diffracted_pattern).astype(complex)
     avg_i = 0
 
+    obj_a = np.zeros_like(obj_avg)
+    obj_b = np.zeros_like(obj_avg)
+
     time_start = time.time()
     for n in range(n_iterations):
         obj_old = np.array(sample_obj)
@@ -373,9 +335,10 @@ def cdi_recon(diffracted_pattern, sample_obj, sup,
             obj_a = np.abs(obj_a)
 
         obj_a = (1 + gamma_2) * obj_a - gamma_2 * sample_obj
-        obj_a = pi_support(obj_a, outside_sup_index)
+        obj_a[outside_sup_index] = 0  # define support
 
-        obj_b = pi_support(sample_obj, outside_sup_index)
+        obj_b = np.array(sample_obj)
+        obj_b[outside_sup_index] = 0  # define support
         obj_b = (1 + gamma_1) * obj_b - gamma_1 * sample_obj
 
         obj_b = pi_modulus(obj_b, diffracted_pattern)
@@ -385,7 +348,8 @@ def cdi_recon(diffracted_pattern, sample_obj, sup,
         sample_obj += beta * (obj_a - obj_b)
 
         # calculate errors
-        obj_error[n] = cal_relative_error(obj_old, sample_obj)
+        obj_error[n] = (np.linalg.norm(sample_obj - obj_old) /
+                        np.linalg.norm(obj_old))
         diff_error[n] = cal_diff_error(sample_obj, diffracted_pattern)
 
         if sw_flag:

--- a/skxray/tests/test_cdi.py
+++ b/skxray/tests/test_cdi.py
@@ -151,7 +151,10 @@ def test_recon():
     init_phase = generate_random_phase_field(diff_v)
     sup = generate_box_support(sup_radius, diff_v.shape)
     # run reconstruction
-    outv, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=False, n_iterations=total_n)
-    outv = np.abs(outv)
+    outv1, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=False, n_iterations=total_n)
+    outv1 = np.abs(outv1)
+
+    outv2, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=True, n_iterations=total_n)
+    outv2 = np.abs(outv2)
     # compare the area of supports
-    assert_array_equal(outv.shape, a.shape)
+    assert_array_equal(outv1.shape, outv2.shape)

--- a/skxray/tests/test_cdi.py
+++ b/skxray/tests/test_cdi.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_array_almost_equal, assert_almost_equal)
 
-from skxray.cdi import (_dist, gauss, cal_relative_error, find_support, pi_support,
+from skxray.cdi import (_dist, gauss, find_support,
                         pi_modulus, cal_diff_error, cdi_recon,
                         generate_random_phase_field,
                         generate_box_support, generate_disk_support)
@@ -65,18 +65,6 @@ def test_gauss():
         assert_almost_equal(0, np.mean(d), decimal=3)
 
 
-def test_relative_error():
-    shape_v = [3, 3]
-    a1 = np.zeros(shape_v)
-    a2 = np.ones(shape_v)
-
-    e1 = cal_relative_error(a2, a1)
-    assert_equal(e1, 1)
-
-    e2 = cal_relative_error(a2, a2)
-    assert_equal(e2, 0)
-
-
 def test_find_support():
     shape_v = [100, 100]
     cenv = shape_v[0]/2
@@ -91,14 +79,6 @@ def test_find_support():
     new_sup[new_sup_index] = 1
     # the area of new support becomes larger
     assert(np.sum(new_sup) == 1760)
-
-
-def test_pi_support():
-    a1 = np.ones([2, 2])
-    a1[0, 0] = 1
-    index = np.where(a1 == 1)
-    a2 = pi_support(a1, index)
-    assert_equal(np.sum(a2), 0)
 
 
 def make_synthetic_data():

--- a/skxray/tests/test_cdi.py
+++ b/skxray/tests/test_cdi.py
@@ -151,10 +151,12 @@ def test_recon():
     init_phase = generate_random_phase_field(diff_v)
     sup = generate_box_support(sup_radius, diff_v.shape)
     # run reconstruction
-    outv1, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=False, n_iterations=total_n)
+    outv1, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=False,
+                                  n_iterations=total_n, sw_step=2)
     outv1 = np.abs(outv1)
 
-    outv2, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=True, n_iterations=total_n)
+    outv2, error_dict = cdi_recon(diff_v, init_phase, sup, sw_flag=True,
+                                  n_iterations=total_n, sw_step=2)
     outv2 = np.abs(outv2)
     # compare the area of supports
     assert_array_equal(outv1.shape, outv2.shape)


### PR DESCRIPTION
The radial_grid from core is for 2D case only, so I still keep the _dist function.